### PR TITLE
Update CHANGELOG.md to fix broken link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 * Support for APL 1.4 [https://aplspec.aka.corp.amazon.com/release-1.4/html/index.html#apl-specification-1-4]
 * Added APL Telemetry Support
 * TV Overlay Portrait is no longer supported
-* Added support for APL Extensions [https://developer.amazon.com/en-US/docs/alexa/alexa-presentation-language/apl-latest-version.html#apl-extensions-and-the-backstack]
+* Added support for APL Extensions [https://developer.amazon.com/en-US/docs/alexa/alexa-presentation-language/apl-changes-1-4.html#apl-extensions-and-the-backstack]
  
 #### Bug fixes
 * Correctly handle GUI state when presenting content over attenuated PlayerInfo card


### PR DESCRIPTION
*Description of changes:*

Latest version is now 1.5 so your link to extensions is broken. I fixed to properly point to the v1.4 section that you wanted to link to.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
